### PR TITLE
Add support for the Polar H7 Bluetooth LE/Smart sensor

### DIFF
--- a/RRR/LubDub.java
+++ b/RRR/LubDub.java
@@ -1,0 +1,40 @@
+import java.io.*;
+
+interface LubDubHandler {
+  void handle(int rr);
+}
+
+final class LubDub {
+  final String uuid;
+  final LubDubHandler handler;
+  
+  private class T extends Thread {
+    public void run() {
+      try {
+        final ProcessBuilder pb = new ProcessBuilder("/bin/bash", "-lc", "lub-dub " + uuid);
+        final Process p = pb.start();
+        final InputStreamReader in = new InputStreamReader(p.getInputStream());
+        final BufferedReader buf = new BufferedReader(in);
+        String line;
+
+        pb.redirectErrorStream(true);
+        while ( (line = buf.readLine ()) != null) {
+          String[] parts = line.split(",");
+          for (int i = 1; i < parts.length; i++)
+            handler.handle(Integer.parseInt(parts[i]));
+        }
+        buf.close();
+      } 
+      catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  LubDub(final String uuid, final LubDubHandler handler) {
+    this.uuid = uuid;
+    this.handler = handler;
+    new T().start();
+  }
+}
+


### PR DESCRIPTION
Not sure if this code is suitable for the main version of Sense Your Heart, but I found it useful for playing with the commercial Polar H7 chest-belt ECG sensor. The changes can be reused under the [ISC license](http://opensource.org/licenses/ISC).

---

Works only on Linux and OS X with BLE support. Assumes that you have acquired the sensor’s UUID (e.g. using a `noble` script or the OS X [LightBlue](https://itunes.apple.com/us/app/lightblue/id639944780) app log) and that you have been wearing the sensor for at least several seconds.

To run:
1. Have Node.js installed.
2. Install lub-dub: `npm install -g lub-dub`.
3. In `RRR/RRR.pde`, set `USEBLE=true`.
4. In `RRR/RRR.pde`, set `UUID` to the sensor’s UUID.
5. Run.

Uses `lub-dub` to fetch data: https://www.npmjs.com/package/lub-dub
